### PR TITLE
Remove personal funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: ['https://www.paypal.com/donate?hosted_button_id=XGVDN2YMXC8TL']


### PR DESCRIPTION
Since I'm no longer the sole maintainer I feel it isn't right to leave a personal donation link up. This removes that link.